### PR TITLE
Implement security vulnerability scan in CI/CD pipeline

### DIFF
--- a/.github/workflows/anchore-scan.yml
+++ b/.github/workflows/anchore-scan.yml
@@ -1,0 +1,45 @@
+#TU: This file is a modified version of a workflow file provided by GitHub, namely
+#    the Security / Code scanning workflow 'Anchore Grype Vulnerability Scan'
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# This workflow checks out code, builds an image, performs a container image
+# vulnerability scan with Anchore's Grype tool, and integrates the results with GitHub Advanced Security
+# code scanning feature.  For more information on the Anchore scan action usage
+# and parameters, see https://github.com/anchore/scan-action. For more
+# information on Anchore's container image scanning tool Grype, see
+# https://github.com/anchore/grype
+name: Anchore Grype vulnerability scan
+
+on:
+  workflow_call:
+  
+permissions:
+  contents: read
+
+jobs:
+  Anchore-Build-Scan:
+    permissions:
+      contents: read # for actions/checkout to fetch code
+      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out the code
+      uses: actions/checkout@v4
+    - name: Build the Docker image
+      run: docker build . --file Dockerfile --tag localbuild/testimage:latest
+    - name: Run the Anchore Grype scan action
+      uses: anchore/scan-action@d5aa5b6cb9414b0c7771438046ff5bcfa2854ed7
+      id: scan
+      with:
+        image: "localbuild/testimage:latest"
+        fail-build: true
+        severity-cutoff: critical
+    - name: Upload vulnerability report
+      uses: github/codeql-action/upload-sarif@v3
+      with:
+        sarif_file: ${{ steps.scan.outputs.sarif }}

--- a/.github/workflows/anchore-scan.yml
+++ b/.github/workflows/anchore-scan.yml
@@ -37,7 +37,8 @@ jobs:
       id: scan
       with:
         image: "localbuild/testimage:latest"
-        fail-build: true
+#TU: Set fail-build from true to false for now during testing
+        fail-build: false
         severity-cutoff: critical
     - name: Upload vulnerability report
       uses: github/codeql-action/upload-sarif@v3

--- a/.github/workflows/anchore-scan.yml
+++ b/.github/workflows/anchore-scan.yml
@@ -1,5 +1,5 @@
-#TU: This file is a modified version of a workflow file provided by GitHub, namely
-#    the Security / Code scanning workflow 'Anchore Grype Vulnerability Scan'
+# This file is a modified version of a workflow file provided by GitHub, namely
+# the Security code-scanning workflow 'Anchore Grype Vulnerability Scan'.
 
 # This workflow uses actions that are not certified by GitHub.
 # They are provided by a third-party and are governed by
@@ -37,7 +37,7 @@ jobs:
       id: scan
       with:
         image: "localbuild/testimage:latest"
-#TU: Set fail-build from true to false for now during testing
+        # Do *not* cause the CI pipeline to fail upon discovering a critical vulnerability
         fail-build: false
         severity-cutoff: critical
     - name: Upload vulnerability report

--- a/.github/workflows/anchore-scan.yml
+++ b/.github/workflows/anchore-scan.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Build the Docker image
       run: docker build . --file Dockerfile --tag localbuild/testimage:latest
     - name: Run the Anchore Grype scan action
-      uses: anchore/scan-action@d5aa5b6cb9414b0c7771438046ff5bcfa2854ed7
+      uses: anchore/scan-action@v6
       id: scan
       with:
         image: "localbuild/testimage:latest"

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -3,8 +3,9 @@ run-name: ci-main
 on:
   workflow_dispatch:
   push:
-    branches:
-    - main
+#TU: Commented out for testing
+#    branches:
+#    - main
   
 jobs:
   anchore-scan:

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -1,27 +1,5 @@
-#
-# This action does the following upon a new commit to the 'main' branch:
-# 1) Creates a new release containing the repository source code, tagging the
-#    release with an appropriate version number, and publishing it on the Github project
-#    page
-# 2) Build a container image, tagging the release with an appropriate version number,
-#    and publishing it on the Github project page
-#
-# Notes:
-# - The version number is incremented every release as described in
-#   https://github.com/mathieudutour/github-tag-action. Note that by default semantic
-#   version numbers are used and the patch number is incremented every release.
-#   Moreover, in accordance with Angular conventional commits convention, the minor or
-#   major number is incremented only upon detection of commits in the history with
-#   certain formats. E.g. a commit beginning with 'feat:', signifying a new feature,
-#   would result in the minor number being incremented. For details on the expected
-#   format of commit messages in this regard see
-#   https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-angular.
-#
-
 name: ci-main
 run-name: ci-main
-
-
 on:
   workflow_dispatch:
   push:
@@ -30,73 +8,10 @@ on:
 #    - main
   
 jobs:
-  vulnerability-scan:
-    runs-on: ubuntu-latest
+  anchore-scan:
     steps:
-      - name: Checkout Code
-        uses: actions/checkout@v4
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Build the Container Image
-        run: docker build . --file Dockerfile --tag localbuild/testimage:latest
-      - name: Scan Image
-        uses: anchore/scan-action@v6
-        id: scan
-        with:
-          image: "localbuild/testimage:latest"
-#TU: Disable failure for now for testing purposes. fail-build is true by default
-          fail-build: false
-          output-format: sarif
-#TU: Option for specifying threshold for causing build to fail
-#	  severity-cutoff: high
-      - name: Upload Anchore Scan SARIF Report
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: ${{ steps.scan.outputs.sarif }}
-#TU: This should be unnecessary, but it is here for debugging
-      - name: Display SARIF file contents
-        env:
-          SARIF_FILE: "${{ steps.scan.outputs.sarif }}"
-        run: |
-          cat $SARIF_FILE
+      - uses: ./.github/workflows/anchore-scan.yml
   tag-container-push:
-    runs-on: ubuntu-latest
-    needs: [vulnerability-scan]
     steps:
-      - uses: actions/checkout@v4
-        with:
-          # Checkout the latest commit on the branch rather than not the commit which instigated the workflow. These are not the same if a bot has pushed a new commit to the branch during the workflow
-          ref: ${{ github.ref }}
-      - name: Bump version and push tag
-        id: tag_version
-        uses: mathieudutour/github-tag-action@v6.2
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          release_branches: main
-      - name: Create a GitHub release
-        uses: ncipollo/release-action@v1
-        with:
-          tag: ${{ steps.tag_version.outputs.new_tag }}
-          name: Release ${{ steps.tag_version.outputs.new_tag }}
-          body: ${{ steps.tag_version.outputs.changelog }}
-      - name: Setup docker auth
-        run: |
-          cat <<EOF > ~/.docker/config.json
-          {
-            "auths": {
-              "ghcr.io": {
-                "auth": "$(echo -n "$GIT_USERNAME:$GIT_PASSWORD" | base64 -w0)"
-              }
-            }
-          }
-          EOF
-        env: # needed to authenticate to github and download the repo
-          GIT_USERNAME: ${{ github.actor }}
-          GIT_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-      - name: Docker build API
-        env:
-          IMAGE_NAME: "ghcr.io/psdi-uk/dlmonte-container/dlmonte:${{ steps.tag_version.outputs.new_tag }}"
-        run: |
-          docker build -t $IMAGE_NAME .
-          docker push $IMAGE_NAME
-
+      - uses: ./.github/workflows/tag-container-push.yml
+    needs: [anchore-scan]

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -9,9 +9,7 @@ on:
   
 jobs:
   anchore-scan:
-    steps:
-      - uses: ./.github/workflows/anchore-scan.yml
+    uses: ./.github/workflows/anchore-scan.yml
   tag-container-push:
-    steps:
-      - uses: ./.github/workflows/tag-container-push.yml
+    uses: ./.github/workflows/tag-container-push.yml
     needs: [anchore-scan]

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -18,19 +18,41 @@
 #   https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-angular.
 #
 
-name: tag-container-push
-run-name: tag-container-push
+name: ci-main
+run-name: ci-main
 
 
 on:
   workflow_dispatch:
   push:
-    branches:
-    - main
+#TU: Commented this out for testing so that pipeline will run on any branch
+#    branches:
+#    - main
   
 jobs:
+  vulnerability-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Build the Container Image
+        run: docker build . --file Dockerfile --tag localbuild/testimage:latest
+      - name: Scan Image
+        uses: anchore/scan-action@v3
+        id: scan
+        with:
+          image: "localbuild/testimage:latest"
+          fail-build: true
+          output-format: sarif
+      - name: Upload Anchore Scan SARIF Report
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: ${{ steps.scan.outputs.sarif }}
   tag-container-push:
     runs-on: ubuntu-latest
+    needs: [vulnerability-scan]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -44,8 +44,8 @@ jobs:
         id: scan
         with:
           image: "localbuild/testimage:latest"
-#TU: Disable failure for now for testing purposes
-#          fail-build: true
+#TU: Disable failure for now for testing purposes; this is true by default
+          fail-build: false
           output-format: sarif
 #TU: Option for specifying threshold for causing build to fail
 #	  severity-cutoff: high

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -56,7 +56,7 @@ jobs:
 #TU: This should be unnecessary, but it is here for debugging
       - name: Display SARIF file contents
         env:
-	  SARIF_FILE: ${{ steps.scan.outputs.sarif }}
+	  SARIF_FILE: "${{ steps.scan.outputs.sarif }}"
         run: |
 	  cat $SARIF_FILE
   tag-container-push:

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Build the Container Image
         run: docker build . --file Dockerfile --tag localbuild/testimage:latest
       - name: Scan Image
-        uses: anchore/scan-action@v3
+        uses: anchore/scan-action@v6
         id: scan
         with:
           image: "localbuild/testimage:latest"

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -53,6 +53,12 @@ jobs:
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
+#TU: This should be unnecessary, but it is here for debugging
+      - name: Display SARIF file contents
+        env:
+	  SARIF_FILE: ${{ steps.scan.outputs.sarif }}
+        run: |
+	  cat $SARIF_FILE
   tag-container-push:
     runs-on: ubuntu-latest
     needs: [vulnerability-scan]

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Build the Container Image
         run: docker build . --file Dockerfile --tag localbuild/testimage:latest
       - name: Scan Image
@@ -50,7 +50,7 @@ jobs:
 #TU: Option for specifying threshold for causing build to fail
 #	  severity-cutoff: high
       - name: Upload Anchore Scan SARIF Report
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
   tag-container-push:

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -3,9 +3,8 @@ run-name: ci-main
 on:
   workflow_dispatch:
   push:
-#TU: Commented this out for testing so that pipeline will run on any branch
-#    branches:
-#    - main
+    branches:
+    - main
   
 jobs:
   anchore-scan:

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -44,8 +44,11 @@ jobs:
         id: scan
         with:
           image: "localbuild/testimage:latest"
-          fail-build: true
+#TU: Disable failure for now for testing purposes
+#          fail-build: true
           output-format: sarif
+#TU: Option for specifying threshold for causing build to fail
+#	  severity-cutoff: high
       - name: Upload Anchore Scan SARIF Report
         uses: github/codeql-action/upload-sarif@v2
         with:

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -3,9 +3,8 @@ run-name: ci-main
 on:
   workflow_dispatch:
   push:
-#TU: Commented out for testing
-#    branches:
-#    - main
+    branches:
+    - main
   
 jobs:
   anchore-scan:

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -44,7 +44,7 @@ jobs:
         id: scan
         with:
           image: "localbuild/testimage:latest"
-#TU: Disable failure for now for testing purposes; this is true by default
+#TU: Disable failure for now for testing purposes. fail-build is true by default
           fail-build: false
           output-format: sarif
 #TU: Option for specifying threshold for causing build to fail

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -56,9 +56,9 @@ jobs:
 #TU: This should be unnecessary, but it is here for debugging
       - name: Display SARIF file contents
         env:
-	  SARIF_FILE: "${{ steps.scan.outputs.sarif }}"
+          SARIF_FILE: "${{ steps.scan.outputs.sarif }}"
         run: |
-	  cat $SARIF_FILE
+          cat $SARIF_FILE
   tag-container-push:
     runs-on: ubuntu-latest
     needs: [vulnerability-scan]

--- a/.github/workflows/tag-container-push.yml
+++ b/.github/workflows/tag-container-push.yml
@@ -1,5 +1,5 @@
 #
-# This action does the following upon a new commit to the 'main' branch:
+# This action does the following:
 # 1) Creates a new release containing the repository source code, tagging the
 #    release with an appropriate version number, and publishing it on the Github project
 #    page

--- a/.github/workflows/tag-container-push.yml
+++ b/.github/workflows/tag-container-push.yml
@@ -1,0 +1,67 @@
+#
+# This action does the following upon a new commit to the 'main' branch:
+# 1) Creates a new release containing the repository source code, tagging the
+#    release with an appropriate version number, and publishing it on the Github project
+#    page
+# 2) Build a container image, tagging the release with an appropriate version number,
+#    and publishing it on the Github project page
+#
+# Notes:
+# - The version number is incremented every release as described in
+#   https://github.com/mathieudutour/github-tag-action. Note that by default semantic
+#   version numbers are used and the patch number is incremented every release.
+#   Moreover, in accordance with Angular conventional commits convention, the minor or
+#   major number is incremented only upon detection of commits in the history with
+#   certain formats. E.g. a commit beginning with 'feat:', signifying a new feature,
+#   would result in the minor number being incremented. For details on the expected
+#   format of commit messages in this regard see
+#   https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-angular.
+#
+
+name: tag-container-push
+run-name: tag-container-push
+
+
+on:
+  workflow_call:
+  
+jobs:
+  tag-container-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Checkout the latest commit on the branch rather than not the commit which instigated the workflow. These are not the same if a bot has pushed a new commit to the branch during the workflow
+          ref: ${{ github.ref }}
+      - name: Bump version and push tag
+        id: tag_version
+        uses: mathieudutour/github-tag-action@v6.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          release_branches: main
+      - name: Create a GitHub release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ steps.tag_version.outputs.new_tag }}
+          name: Release ${{ steps.tag_version.outputs.new_tag }}
+          body: ${{ steps.tag_version.outputs.changelog }}
+      - name: Setup docker auth
+        run: |
+          cat <<EOF > ~/.docker/config.json
+          {
+            "auths": {
+              "ghcr.io": {
+                "auth": "$(echo -n "$GIT_USERNAME:$GIT_PASSWORD" | base64 -w0)"
+              }
+            }
+          }
+          EOF
+        env: # needed to authenticate to github and download the repo
+          GIT_USERNAME: ${{ github.actor }}
+          GIT_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+      - name: Docker build API
+        env:
+          IMAGE_NAME: "ghcr.io/psdi-uk/dlmonte-container/dlmonte:${{ steps.tag_version.outputs.new_tag }}"
+        run: |
+          docker build -t $IMAGE_NAME .
+          docker push $IMAGE_NAME

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,24 +15,38 @@
 #   docker build -t dlmonte .
 #
 
-FROM debian:bookworm-slim
+#TU: FOR DEBIAN...
+#FROM debian:bookworm-slim
+#TU: FOR ALPINE...
+FROM alpine:latest
 
 WORKDIR /app
 
 # Install system dependencies
-RUN apt-get update
-RUN apt-get install -y \
-    gfortran \
+#TU: FOR DEBIAN...
+#RUN apt-get update
+#RUN apt-get install -y \
+#    gfortran \
+#    make \
+#    unzip \
+#    wget
+#TU: FOR ALPINE...
+RUN apk update
+RUN apk add \
     make \
+    gfortran \
     unzip \
     wget
-		
+
 # Install DLMONTE
 RUN wget -q https://gitlab.com/dl_monte/DL_MONTE-2/-/archive/master/DL_MONTE-2-master.zip
 RUN unzip DL_MONTE-2-master.zip
 RUN rm DL_MONTE-2-master.zip
 WORKDIR /app/DL_MONTE-2-master
-RUN bash build.sh SRL dir gfortran
+#TU: FOR DEBIAN...
+#RUN bash build.sh SRL dir gfortran
+#TU: FOR ALPINE...
+RUN sh build.sh SRL dir gfortran
 
 ENV PATH=/app/DL_MONTE-2-master/bin:$PATH
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,22 +15,11 @@
 #   docker build -t dlmonte .
 #
 
-#TU: FOR DEBIAN...
-#FROM debian:bookworm-slim
-#TU: FOR ALPINE...
 FROM alpine:latest
 
 WORKDIR /app
 
 # Install system dependencies
-#TU: FOR DEBIAN...
-#RUN apt-get update
-#RUN apt-get install -y \
-#    gfortran \
-#    make \
-#    unzip \
-#    wget
-#TU: FOR ALPINE...
 RUN apk update
 RUN apk add \
     make \
@@ -43,9 +32,6 @@ RUN wget -q https://gitlab.com/dl_monte/DL_MONTE-2/-/archive/master/DL_MONTE-2-m
 RUN unzip DL_MONTE-2-master.zip
 RUN rm DL_MONTE-2-master.zip
 WORKDIR /app/DL_MONTE-2-master
-#TU: FOR DEBIAN...
-#RUN bash build.sh SRL dir gfortran
-#TU: FOR ALPINE...
 RUN sh build.sh SRL dir gfortran
 
 ENV PATH=/app/DL_MONTE-2-master/bin:$PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 #   docker build -t dlmonte .
 #
 
-FROM python:3.8-slim-buster
+FROM debian:bookworm-slim
 
 WORKDIR /app
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ about the program.
 
 ## Obtaining an image
 
-Images can be found in  the 'Packages' section of this GitHub project.
+Images can be found in  the [Packages](https://github.com/PSDI-UK/dlmonte-container/pkgs/container/dlmonte-container%2Fdlmonte)
+section of this GitHub project.
 Commands are provided there to pull a specific version to your local
 instance of docker, e.g.
 ```
@@ -34,6 +35,16 @@ execute DL_MONTE in the current directory, and DL_MONTE output files
 will be created in the directory. Upon completion of the DL_MONTE
 executable the container will terminate.
 
+## Security vulnerabilities
+
+The latest version of this container image uses [Apline Linux](https://hub.docker.com/_/alpine)
+as a base image. **Note that this base image, and the packages
+installed on it in order to compile DL_MONTE when creating the image,
+may have security vulnerabilities.** Use this image at your own risk.
+Details of the image and the aforementioned packages installed on
+Alpine Linux can be found in the `Dockerfile`.
+
+
 ## Building the image
 
 To use the `Dockerfile` to build the image locally the command is:
@@ -45,18 +56,38 @@ is also assumed that the `Dockerfile` file is in the current
 directory.
 
 ## Notes for developers
-- Some example DL_MONTE input files are provided in the directory
-  `dlmonte_example_input`. (Note that DL_MONTE expects a minimum of
-  3 files: `CONTROL`,`CONFIG`, and `FIELD`. Such files are provided therein).
-  Invoking DL_MONTE using the container
-  image as described above in the same directory as these files
-  should result in the creation of a number of files ending in
-  `.000`. Moreover, the `OUTPUT.000` file, which contains a log
-  created by DL_MONTE during execution, should conclude with 'normal
-  exit'.
-- The file `psdi-tool-store-metadata.json` houses metadata for the
-  container image which is used by the
-  [PSDI Tool Store](https://psdi-uk.github.io/psdi-tool-store/). Ideally the
-  information in this file would be updated as part of a CI/CD pipeline,
-  but for now its contents are 'static'. **This is something to do
-  in the future.**
+
+### Testing the container image
+Some example DL_MONTE input files are provided in the directory
+`dlmonte_example_input`. (Note that DL_MONTE expects a minimum of
+3 files: `CONTROL`,`CONFIG`, and `FIELD`. Such files are provided therein).
+Invoking DL_MONTE using the container
+image as described above in the same directory as these files
+should result in the creation of a number of files ending in
+`.000`. Moreover, the `OUTPUT.000` file, which contains a log
+created by DL_MONTE during execution, should conclude with 'normal
+exit'. In the future, the CI/CD pipeline could incorporate checking that the
+container image behaves in this way. Better yet, the container image
+could be checked against the entire
+[DL_MONTE test suite](https://gitlab.com/dl_monte/dl_monte_tests).
+
+### CI/CD pipeline
+Note that GitHub Actions is used to implement a CI/CD pipeline which, every
+commit:
+1. Builds the container image and scans it for **security vulberabilities**.
+   Reports regarding vulnerabilities can be found
+   [here](https://github.com/PSDI-UK/dlmonte-container/security/code-scanning).
+2. Builds the container image, gives it a version tag, and publishes it in
+   the [Packages](https://github.com/PSDI-UK/dlmonte-container/pkgs/container/dlmonte-container%2Fdlmonte)
+   section of this project.
+3. Creates an archive containing the source code of this repository, gives
+   it a version tag, and publishes it in the [Releases](https://github.com/PSDI-UK/dlmonte-container/releases)
+   section.
+
+### Metadata for the PSDI Resource Catalogue
+The file `psdi-tool-store-metadata.json` houses metadata for the
+container image which is used by the
+[PSDI Tool Store](https://psdi-uk.github.io/psdi-tool-store/). Ideally the
+information in this file would be updated as part of a CI/CD pipeline,
+but for now its contents are 'static'. This is something to explore
+in the future.

--- a/README.md
+++ b/README.md
@@ -82,6 +82,15 @@ commit:
    it a version tag, and publishes it in the [Releases](https://github.com/PSDI-UK/dlmonte-container/releases)
    section.
 
+It is important to keep this pipeline up to date with regards to upstream
+dependencies. For example, the pipeline uses a particular version of the
+`anchore/scan-action` Action (e.g. `anchore/scan-action@v6` means version 6).
+This should be updated if a new version of this Action is released. Note that
+certain Actions will print warnings if, e.g. certain features in the Actions
+which are used in this repo are to be deprecated; pay attention to such
+warnings.
+
+
 ### Metadata for the PSDI Resource Catalogue
 The file `psdi-tool-store-metadata.json` houses metadata for the
 container image which is used by the

--- a/README.md
+++ b/README.md
@@ -38,12 +38,10 @@ executable the container will terminate.
 ## Security vulnerabilities
 
 The latest version of this container image uses [Apline Linux](https://hub.docker.com/_/alpine)
-as a base image. **Note that this base image, and the packages
-installed on it in order to compile DL_MONTE when creating the image,
-may have security vulnerabilities.** Use this image at your own risk.
-Details of the image and the aforementioned packages installed on
-Alpine Linux can be found in the `Dockerfile`.
-
+as a base image. **Note that the base image, and the packages
+installed onto it in order to compile DL_MONTE when creating the DL_MONTE
+container image, may have security vulnerabilities.** Hence use this image at your own risk.
+See the `Dockerfile` for more details regarding the contents of this image.
 
 ## Building the image
 
@@ -74,7 +72,7 @@ could be checked against the entire
 ### CI/CD pipeline
 Note that GitHub Actions is used to implement a CI/CD pipeline which, every
 commit:
-1. Builds the container image and scans it for **security vulberabilities**.
+1. Builds the container image and scans it for **security vulnerabilities**.
    Reports regarding vulnerabilities can be found
    [here](https://github.com/PSDI-UK/dlmonte-container/security/code-scanning).
 2. Builds the container image, gives it a version tag, and publishes it in


### PR DESCRIPTION
This PR adds a job to the CI/CD pipeline which performs a scan, using [Anchore Grype](https://github.com/anchore/grype), to check for security vulnerabilities in the container image. 

See https://github.com/PSDI-UK/dlmonte-container/actions/runs/12415222863 for a successful run of the pipeline, and see the README for details of how to access the results of vulnerability scans. 

This PR closes issue [PSDI-296](https://stfc.atlassian.net/browse/PSDI-296).