### PR TITLE
Fix bug due to missing library in Alpine, and introduce light testing for image

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the code
-      - uses: actions/checkout@v4
+        uses: actions/checkout@v4
       - name: Build the image
         run: docker build . --file Dockerfile --tag localbuild/testimage:latest
       # We test the image by running it as described in the README: running it while

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -28,4 +28,5 @@ jobs:
       - name: Check for creation of DL_MONTE output files
         working-directory: dlmonte_example_input
         run: |
+          ls
           [ -f OUTPUT.000 ]

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -27,4 +27,5 @@ jobs:
       # behaving as expected. If not, something has gone wrong.
       - name: Check for creation of DL_MONTE output files
         working-directory: dlmonte_example_input
-        run: [ -f OUTPUT.000 ]
+        run: |
+	  [ -f OUTPUT.000 ]

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -28,4 +28,4 @@ jobs:
       - name: Check for creation of DL_MONTE output files
         working-directory: dlmonte_example_input
         run: |
-	  [ -f OUTPUT.000 ]
+          [ -f OUTPUT.000 ]

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,30 @@
+# Builds the image and runs some tests to ensure it works as expected
+
+name: build-and-test
+run-name: build-and-test
+
+on:
+  workflow_call:
+  
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the code
+      - uses: actions/checkout@v4
+      - name: Build the image
+        run: docker build . --file Dockerfile --tag localbuild/testimage:latest
+      # We test the image by running it as described in the README: running it while
+      # binding to a local directory containing DL_MONTE input files. The result should
+      # be that DL_MONTE output files are created in that directory. Here we use the
+      # directory in the repo which contains example DL_MONTE input files.
+      - name: Run DL_MONTE simulation with image using example input files
+        working-directory: dlmonte_example_input
+        run: docker run -v ${PWD}:/data localbuild/testimage:latest
+      # Upon sucessfully invoking a DL_MONTE simulation in a directory containing DL_MONTE
+      # input files, various output files should be created. This step checks that the
+      # main DL_MONTE output file, OUTPUT.000, has been created. If so, the image is
+      # behaving as expected. If not, something has gone wrong.
+      - name: Check for creation of DL_MONTE output files
+        working-directory: dlmonte_example_input
+        run: [ -f OUTPUT.000 ]

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -11,7 +11,7 @@ jobs:
   # Run this only on main branch
   anchore-scan:
     uses: ./.github/workflows/anchore-scan.yml
-    needs: [tests]
+    needs: [build-and-test]
     if: github.ref == 'refs/heads/main'
   # Run this only on main branch
   tag-container-push:

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -3,12 +3,18 @@ run-name: ci-main
 on:
   workflow_dispatch:
   push:
-    branches:
-    - main
   
 jobs:
+  # Run this on all branches
+  build-and-test:
+    uses: ./.github/workflows/build-and-test.yml
+  # Run this only on main branch
   anchore-scan:
     uses: ./.github/workflows/anchore-scan.yml
+    needs: [tests]
+    if: github.ref == 'refs/heads/main'
+  # Run this only on main branch
   tag-container-push:
     uses: ./.github/workflows/tag-container-push.yml
     needs: [anchore-scan]
+    if: github.ref == 'refs/heads/main'

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,9 +25,8 @@ RUN apk add \
     make \
     gfortran \
     unzip \
-    wget 
-##TU: Removed for testing purposes
-#  musl-dev
+    wget \
+    musl-dev
 
 # Install DLMONTE
 RUN wget -q https://gitlab.com/dl_monte/DL_MONTE-2/-/archive/master/DL_MONTE-2-master.zip

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,9 @@ RUN apk add \
     make \
     gfortran \
     unzip \
-    wget \
-    musl-dev
+    wget 
+##TU: Removed for testing purposes
+#  musl-dev
 
 # Install DLMONTE
 RUN wget -q https://gitlab.com/dl_monte/DL_MONTE-2/-/archive/master/DL_MONTE-2-master.zip

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,8 @@ RUN apk add \
     make \
     gfortran \
     unzip \
-    wget
+    wget \
+    musl-dev
 
 # Install DLMONTE
 RUN wget -q https://gitlab.com/dl_monte/DL_MONTE-2/-/archive/master/DL_MONTE-2-master.zip

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ image as described above in the same directory as these files
 should result in the creation of a number of files ending in
 `.000`. Moreover, the `OUTPUT.000` file, which contains a log
 created by DL_MONTE during execution, should conclude with 'normal
-exit'. As mentioned below the CI/CD pipeline incorporateing a job to ensure
+exit'. As mentioned below, the CI/CD pipeline incorporates a job to ensure
 that the container image behaves in this way. In the future it would be
 nice if the container image were checked against the entire
 [DL_MONTE test suite](https://gitlab.com/dl_monte/dl_monte_tests).

--- a/README.md
+++ b/README.md
@@ -64,21 +64,26 @@ image as described above in the same directory as these files
 should result in the creation of a number of files ending in
 `.000`. Moreover, the `OUTPUT.000` file, which contains a log
 created by DL_MONTE during execution, should conclude with 'normal
-exit'. In the future, the CI/CD pipeline could incorporate checking that the
-container image behaves in this way. Better yet, the container image
-could be checked against the entire
+exit'. As mentioned below the CI/CD pipeline incorporateing a job to ensure
+that the container image behaves in this way. In the future it would be
+nice if the container image were checked against the entire
 [DL_MONTE test suite](https://gitlab.com/dl_monte/dl_monte_tests).
 
 ### CI/CD pipeline
 Note that GitHub Actions is used to implement a CI/CD pipeline which, every
 commit:
-1. Builds the container image and scans it for **security vulnerabilities**.
+1. Builds the container image and performs light testing to ensure that it works.
+   The testing currently entails ensuring that the DL_MONTE output file `OUTPUT.000`
+   is generated if the image is used to invoke a DL_MONTE simulation,
+   as described above, using the example input DL_MONTE files in the
+   `dlmonte_example_input` directory. 
+2. Builds the container image and scans it for **security vulnerabilities**.
    Reports regarding vulnerabilities can be found
    [here](https://github.com/PSDI-UK/dlmonte-container/security/code-scanning).
-2. Builds the container image, gives it a version tag, and publishes it in
+3. Builds the container image, gives it a version tag, and publishes it in
    the [Packages](https://github.com/PSDI-UK/dlmonte-container/pkgs/container/dlmonte-container%2Fdlmonte)
    section of this project.
-3. Creates an archive containing the source code of this repository, gives
+4. Creates an archive containing the source code of this repository, gives
    it a version tag, and publishes it in the [Releases](https://github.com/PSDI-UK/dlmonte-container/releases)
    section.
 


### PR DESCRIPTION
This PR fixes a bug introduced in my previous PR [Implement security vulnerability scan in CI/CD pipeline](https://github.com/PSDI-UK/dlmonte-container/pull/1). The bug was that a necessary library was not installed in the image, preventing the DL_MONTE executable from being created while building the image from the `Dockerfile`. Without the DL_MONTE executable in the image, it cannot serve its purpose: an error would be thrown if one tried to use the image to initiate any DL_MONTE simulations.

This PR also adds a test to the CI/CD pipeline which checks that the DL_MONTE image works. The test uses the image to invoke a DL_MONTE simulating using example DL_MONTE input files, and checks that the main DL_MONTE output file `OUTPUT.000` is created. Adding this test should catch bugs in repo which result in the DL_MONTE executable not being created.

See the `README.md` for more information. See https://github.com/PSDI-UK/dlmonte-container/actions/runs/12466133604 for a workflow which failed due to the executable not being created, i.e. a workflow which catches a bug in a DL_MONTE container image using the aforementioned test. See https://github.com/PSDI-UK/dlmonte-container/actions/runs/12466317523 for a workflow which uses the test to verify that a working DL_MONTE image is indeed working correctly.