### PR TITLE
Implement 'latest' tag for container images

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -16,5 +16,6 @@ jobs:
   # Run this only on main branch
   tag-container-push:
     uses: ./.github/workflows/tag-container-push.yml
-    needs: [anchore-scan]
-    if: github.ref == 'refs/heads/main'
+#TODO: Enable this after testing
+#    needs: [anchore-scan]
+#    if: github.ref == 'refs/heads/main'

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -16,6 +16,5 @@ jobs:
   # Run this only on main branch
   tag-container-push:
     uses: ./.github/workflows/tag-container-push.yml
-#TODO: Enable this after testing
-#    needs: [anchore-scan]
-#    if: github.ref == 'refs/heads/main'
+    needs: [anchore-scan]
+    if: github.ref == 'refs/heads/main'

--- a/.github/workflows/tag-container-push.yml
+++ b/.github/workflows/tag-container-push.yml
@@ -66,7 +66,7 @@ jobs:
         env:
           # Note that this is the name of the image *without the tag*
           IMAGE_NAME: "ghcr.io/psdi-uk/dlmonte-container/dlmonte"
-	  TAG: ${{ steps.tag_version.outputs.new_tag }}
+          TAG: ${{ steps.tag_version.outputs.new_tag }}
         run: |
           # Build and push image with conventional version tag
           docker build -t $IMAGE_NAME:$TAG .
@@ -75,4 +75,4 @@ jobs:
             echo "Detected $TAG corresponds to a release version. Assigning image 'latest' tag"
             docker tag $IMAGE_NAME:$TAG $IMAGE_NAME:latest
             docker push $IMAGE_NAME:latest
-	  fi
+          fi

--- a/.github/workflows/tag-container-push.yml
+++ b/.github/workflows/tag-container-push.yml
@@ -66,12 +66,13 @@ jobs:
         env:
           # Note that this is the name of the image *without the tag*
           IMAGE_NAME: "ghcr.io/psdi-uk/dlmonte-container/dlmonte"
+	  TAG: ${{ steps.tag_version.outputs.new_tag }}
         run: |
           # Build and push image with conventional version tag
-          docker build -t ${IMAGE_NAME}:${{ steps.tag_version.outputs.new_tag }} .
-          docker push $IMAGE_NAME:${{ steps.tag_version.outputs.new_tag }}
-          if [[ "${{ steps.tag_version.outputs.new_tag }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Detected ${{ steps.tag_version.outputs.new_tag }} corresponds to a release version. Assigning image 'latest' tag"
-            docker tag ${IMAGE_NAME}:${{ steps.tag_version.outputs.new_tag }} ${IMAGE_NAME}:latest
-            docker push ${IMAGE_NAME}:latest
+          docker build -t $IMAGE_NAME:$TAG .
+          docker push $IMAGE_NAME:$TAG
+          if [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Detected $TAG corresponds to a release version. Assigning image 'latest' tag"
+            docker tag $IMAGE_NAME:$TAG $IMAGE_NAME:latest
+            docker push $IMAGE_NAME:latest
 	  fi

--- a/.github/workflows/tag-container-push.yml
+++ b/.github/workflows/tag-container-push.yml
@@ -71,9 +71,9 @@ jobs:
           # Build and push image with conventional version tag
           docker build -t $IMAGE_NAME:$TAG .
           docker push $IMAGE_NAME:$TAG
-#TODO:  Enable this and indent by 2 within if block after testing
-#          if [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          #TODO:  Enable this and restore indent in if block after testing
+          #          if [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
           echo "Detected $TAG corresponds to a release version. Assigning image 'latest' tag"
           docker tag $IMAGE_NAME:$TAG $IMAGE_NAME:latest
           docker push $IMAGE_NAME:latest
-#          fi
+          #          fi

--- a/.github/workflows/tag-container-push.yml
+++ b/.github/workflows/tag-container-push.yml
@@ -71,9 +71,8 @@ jobs:
           # Build and push image with conventional version tag
           docker build -t $IMAGE_NAME:$TAG .
           docker push $IMAGE_NAME:$TAG
-          #TODO:  Enable this and restore indent in if block after testing
-          #          if [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-          echo "Detected $TAG corresponds to a release version. Assigning image 'latest' tag"
-          docker tag $IMAGE_NAME:$TAG $IMAGE_NAME:latest
-          docker push $IMAGE_NAME:latest
-          #          fi
+          if [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Detected $TAG corresponds to a release version. Assigning image 'latest' tag"
+            docker tag $IMAGE_NAME:$TAG $IMAGE_NAME:latest
+            docker push $IMAGE_NAME:latest
+          fi

--- a/.github/workflows/tag-container-push.yml
+++ b/.github/workflows/tag-container-push.yml
@@ -70,7 +70,7 @@ jobs:
           # Build and push image with conventional version tag
           docker build -t ${IMAGE_NAME}:${{ steps.tag_version.outputs.new_tag }} .
           docker push $IMAGE_NAME:${{ steps.tag_version.outputs.new_tag }}
-          if [[ ${{ steps.tag_version.outputs.new_tag }} =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          if [[ "${{ steps.tag_version.outputs.new_tag }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "Detected ${{ steps.tag_version.outputs.new_tag }} corresponds to a release version. Assigning image 'latest' tag"
             docker tag ${IMAGE_NAME}: ${IMAGE_NAME}:latest
             docker push ${IMAGE_NAME}:latest

--- a/.github/workflows/tag-container-push.yml
+++ b/.github/workflows/tag-container-push.yml
@@ -72,6 +72,6 @@ jobs:
           docker push $IMAGE_NAME:${{ steps.tag_version.outputs.new_tag }}
           if [[ "${{ steps.tag_version.outputs.new_tag }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "Detected ${{ steps.tag_version.outputs.new_tag }} corresponds to a release version. Assigning image 'latest' tag"
-            docker tag ${IMAGE_NAME}: ${IMAGE_NAME}:latest
+            docker tag ${IMAGE_NAME}:${{ steps.tag_version.outputs.new_tag }} ${IMAGE_NAME}:latest
             docker push ${IMAGE_NAME}:latest
 	  fi

--- a/.github/workflows/tag-container-push.yml
+++ b/.github/workflows/tag-container-push.yml
@@ -71,8 +71,9 @@ jobs:
           # Build and push image with conventional version tag
           docker build -t $IMAGE_NAME:$TAG .
           docker push $IMAGE_NAME:$TAG
-          if [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Detected $TAG corresponds to a release version. Assigning image 'latest' tag"
-            docker tag $IMAGE_NAME:$TAG $IMAGE_NAME:latest
-            docker push $IMAGE_NAME:latest
-          fi
+#TODO:  Enable this and indent by 2 within if block after testing
+#          if [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          echo "Detected $TAG corresponds to a release version. Assigning image 'latest' tag"
+          docker tag $IMAGE_NAME:$TAG $IMAGE_NAME:latest
+          docker push $IMAGE_NAME:latest
+#          fi

--- a/.github/workflows/tag-container-push.yml
+++ b/.github/workflows/tag-container-push.yml
@@ -64,7 +64,7 @@ jobs:
           GIT_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push Docker image with version tags
         env:
-	  # Note that this is the name of the image *without the tag*
+          # Note that this is the name of the image *without the tag*
           IMAGE_NAME: "ghcr.io/psdi-uk/dlmonte-container/dlmonte"
         run: |
           # Build and push image with conventional version tag

--- a/.github/workflows/tag-container-push.yml
+++ b/.github/workflows/tag-container-push.yml
@@ -1,10 +1,13 @@
 #
 # This action does the following:
-# 1) Creates a new release containing the repository source code, tagging the
-#    release with an appropriate version number, and publishing it on the Github project
+# 1) Create a new release containing the repository source code, tag the
+#    release with an appropriate version tag, and publish it on the GitHub project
 #    page
-# 2) Build a container image, tagging the release with an appropriate version number,
-#    and publishing it on the Github project page
+# 2) Build a container image, tag the release with an appropriate version tag,
+#    and publish it on the GitHub project page
+# 3) If the version tag matches the regex '^v[0-9]+\.[0-9]+\.[0-9]+$', i.e. it corresponds
+#    to a 'release' version, then additionally tag the container image with the
+#    'latest' tag and publish it on the GitHub project page
 #
 # Notes:
 # - The version number is incremented every release as described in
@@ -59,9 +62,16 @@ jobs:
         env: # needed to authenticate to github and download the repo
           GIT_USERNAME: ${{ github.actor }}
           GIT_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-      - name: Docker build API
+      - name: Build and push Docker image with version tags
         env:
-          IMAGE_NAME: "ghcr.io/psdi-uk/dlmonte-container/dlmonte:${{ steps.tag_version.outputs.new_tag }}"
+	  # Note that this is the name of the image *without the tag*
+          IMAGE_NAME: "ghcr.io/psdi-uk/dlmonte-container/dlmonte"
         run: |
-          docker build -t $IMAGE_NAME .
-          docker push $IMAGE_NAME
+          # Build and push image with conventional version tag
+          docker build -t ${IMAGE_NAME}:${{ steps.tag_version.outputs.new_tag }} .
+          docker push $IMAGE_NAME:${{ steps.tag_version.outputs.new_tag }}
+          if [[ ${{ steps.tag_version.outputs.new_tag }} =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Detected ${{ steps.tag_version.outputs.new_tag }} corresponds to a release version. Assigning image 'latest' tag"
+            docker tag ${IMAGE_NAME}: ${IMAGE_NAME}:latest
+            docker push ${IMAGE_NAME}:latest
+	  fi


### PR DESCRIPTION
In this PR I modify the CI/CD pipeline so that whenever a container image is published in the container registry for this repo, and the tag for the container image is of the form `v*.*.*` (where `*` are non-negative integers), the container image is additionally given the 'latest' tag. 

Evidence that the pipeline can generate a 'latest' tag successfully can be found at https://github.com/PSDI-UK/dlmonte-container/pkgs/container/dlmonte-container%2Fdlmonte; note that 'latest' tag can be seen to be in operation. Note, however, that in this case to generate the 'latest' tag I - for testing purposes - disabled the check that the tag has the form `v*.*.*`. (The job which generated the 'latest' tag here is https://github.com/PSDI-UK/dlmonte-container/actions/runs/14128560878/job/39583141306). When the PR is merged the pipeline will have the desired behaviour: 'latest' tags will only be generated for container images which have tags of the form  `v*.*.*`.

This PR completes the part of https://stfc.atlassian.net/browse/PSDI-477 pertaining to the `dlmonte-container` repo.
