### PR TITLE
Change license and add disclaimer regarding implied container image license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,29 +1,12 @@
-BSD 3-Clause License
-
 Copyright (c) 2024, Science and Technologies Facilities Research Council
-All rights reserved.
 
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
+Permission to use, copy, modify, and/or distribute this software for
+any purpose with or without fee is hereby granted.
 
-1. Redistributions of source code must retain the above copyright notice, this
-   list of conditions and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the above copyright notice,
-   this list of conditions and the following disclaimer in the documentation
-   and/or other materials provided with the distribution.
-
-3. Neither the name of the copyright holder nor the names of its
-   contributors may be used to endorse or promote products derived from
-   this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+THE SOFTWARE IS PROVIDED “AS IS” AND THE AUTHOR DISCLAIMS ALL
+WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE
+FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY
+DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
+AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT
+OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ code describes container images or processes to build container images,
 the software license applicable to these container images will in general not be the
 same as `LICENSE`. This is because a container image typically includes binaries
 and source code from many pieces of software; the software license for a
-container image depends on the licenses of its constitutent software.
+container image depends on the licenses of its constituent software.
 This should be kept in mind when using any container image linked to this
 repository, or any container image built using code in this repository.
 

--- a/README.md
+++ b/README.md
@@ -113,10 +113,9 @@ warnings.
 
 ### Metadata for the PSDI Resource Catalogue
 The file `psdi-tool-store-metadata.json` houses metadata for the
-container image which is used by the
+container image which is used by the prototype
 [PSDI Tool Store](https://psdi-uk.github.io/psdi-tool-store/). Ideally the
 information in this file would be updated as part of a CI/CD pipeline,
-but for now its contents are 'static'. This is something to explore
-in the future.
+but for now its contents are 'static'. This is something that may be explored.
 
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ execute DL_MONTE in the current directory, and DL_MONTE output files
 will be created in the directory. Upon completion of the DL_MONTE
 executable the container will terminate.
 
+
 ## Security vulnerabilities
 
 The latest version of this container image uses [Apline Linux](https://hub.docker.com/_/alpine)
@@ -52,6 +53,20 @@ docker build -t dlmonte .
 where it is assumed that the image is to be named `dlmonte` and it
 is also assumed that the `Dockerfile` file is in the current
 directory.
+
+
+## License
+
+The code in this repository is provided under the conditions
+described in the `LICENSE` file in this repository. However, while some of this
+code describes container images or processes to build container images,
+the software license applicable to these container images will in general not be the
+same as `LICENSE`. This is because a container image typically includes binaries
+and source code from many pieces of software; hence the software license for a
+container image depends on the licenses of its constitutent software.
+Before using any container images linked to this repository, you must therefore
+ensure that you adhere to the licensing conditions of its constituent software.
+
 
 ## Notes for developers
 
@@ -103,3 +118,5 @@ container image which is used by the
 information in this file would be updated as part of a CI/CD pipeline,
 but for now its contents are 'static'. This is something to explore
 in the future.
+
+

--- a/README.md
+++ b/README.md
@@ -62,10 +62,10 @@ described in the `LICENSE` file in this repository. However, while some of this
 code describes container images or processes to build container images,
 the software license applicable to these container images will in general not be the
 same as `LICENSE`. This is because a container image typically includes binaries
-and source code from many pieces of software; hence the software license for a
+and source code from many pieces of software; the software license for a
 container image depends on the licenses of its constitutent software.
-Before using any container images linked to this repository, you must therefore
-ensure that you adhere to the licensing conditions of its constituent software.
+This should be kept in mind when using any container image linked to this
+repository, or any container image built using code in this repository.
 
 
 ## Notes for developers


### PR DESCRIPTION
I have changed the license for the repo to the [Zero-Clause BSD](https://opensource.org/license/0bsd) license, which allows any use of the repo's source code without any requirement of attribution. 

I have also added a `License` section to the `README` to clarify to users that the software license for the source code in the repo may not be the same as for any container images.