### PR TITLE
Build and publish Apptainer image as part of GitHub Actions pipeline

### DIFF
--- a/.github/workflows/tag-container-push.yml
+++ b/.github/workflows/tag-container-push.yml
@@ -5,7 +5,9 @@
 #    page
 # 2) Build a container image, tag the release with an appropriate version tag,
 #    and publish it on the GitHub project page
-# 3) If the version tag matches the regex '^v[0-9]+\.[0-9]+\.[0-9]+$', i.e. it corresponds
+# 3) Build an apptainer container image, tagging the release with an appropriate version tag,
+#    and publishing it on the GitHub project page
+# 4) If the version tag matches the regex '^v[0-9]+\.[0-9]+\.[0-9]+$', i.e. it corresponds
 #    to a 'release' version, then additionally tag the container image with the
 #    'latest' tag and publish it on the GitHub project page
 #
@@ -65,14 +67,32 @@ jobs:
       - name: Build and push Docker image with version tags
         env:
           # Note that this is the name of the image *without the tag*
-          IMAGE_NAME: "ghcr.io/psdi-uk/dlmonte-container/dlmonte"
+          DOCKER_IMAGE_NAME: "ghcr.io/psdi-uk/dlmonte-container/dlmonte"
           TAG: ${{ steps.tag_version.outputs.new_tag }}
         run: |
-          # Build and push image with conventional version tag
-          docker build -t $IMAGE_NAME:$TAG .
-          docker push $IMAGE_NAME:$TAG
+          docker build -t $DOCKER_IMAGE_NAME:$TAG .
+          docker push $DOCKER_IMAGE_NAME:$TAG
           if [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "Detected $TAG corresponds to a release version. Assigning image 'latest' tag"
-            docker tag $IMAGE_NAME:$TAG $IMAGE_NAME:latest
-            docker push $IMAGE_NAME:latest
+            docker tag $DOCKER_IMAGE_NAME:$TAG $DOCKER_IMAGE_NAME:latest
+            docker push $DOCKER_IMAGE_NAME:latest
+          fi
+      - name: Install Apptainer
+        run: |
+          sudo apt install -y software-properties-common
+          sudo add-apt-repository -y ppa:apptainer/ppa
+          sudo apt install -y apptainer
+          apptainer --version
+      - name: Build Apptainer image from the Docker image and push with version tags
+        env:
+          # Note that these are the names of the images *without the tag*
+          DOCKER_IMAGE_NAME: "ghcr.io/psdi-uk/dlmonte-container/dlmonte"
+          APPTAINER_IMAGE_NAME: "ghcr.io/psdi-uk/dlmonte-container/dlmonte-sif"
+          TAG: ${{ steps.tag_version.outputs.new_tag }}
+        run: |
+          apptainer build container.sif docker-daemon://$DOCKER_IMAGE_NAME:$TAG
+          apptainer push container.sif oras://$APPTAINER_IMAGE_NAME:$TAG
+          if [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Detected $TAG corresponds to a release version. Assigning image 'latest' tag"
+            apptainer push container.sif oras://$APPTAINER_IMAGE_NAME:latest
           fi


### PR DESCRIPTION
I have modified the CI/CD pipeline so that it builds, version-tags and publishes a Singularity Image Format (SIF) image using Apptainer every commit. SIF images will be published in the GitHub Container Registry linked to this repo in the `dlmonte-sif` package.

Note that the approach I took is the same as that I employed in other container-image PSDI repositories, namely (https://github.com/[PSDI-UK/metadise-container](https://github.com/PSDI-UK/metadise-container) and https://github.com/[PSDI-UK/data-transfer-container](https://github.com/PSDI-UK/data-transfer-container). The code I used to build and push the SIF images is identical to that used in those repos (aside obviously from the image names). See, e.g. the bottom of https://github.com/PSDI-UK/data-transfer-container/blob/main/.github/workflows/tag-container-push.yml.

This PR closes Jira issue https://stfc.atlassian.net/browse/PSDI-440.
